### PR TITLE
Update permlinux.go to work on MacOS

### DIFF
--- a/permlinux.go
+++ b/permlinux.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux darwin
 
 package flop
 


### PR DESCRIPTION
Make flop work on MacOS. I used a SimpleCopy, and it worked fine. Happy to test more, if needed.